### PR TITLE
allows Twin Spin to be used with the sign

### DIFF
--- a/src/Lua/Hooks/Player.lua
+++ b/src/Lua/Hooks/Player.lua
@@ -232,6 +232,8 @@ addHook("AbilitySpecial", function (p)
 	and not (p.pflags & PF_THOKKED) then
 		p.actionspd = 40*FU
 	end
-
-	return not FangsHeist.canUseAbility(p)
+	
+	if p.charability ~= CA_TWINSPIN then
+		return not FangsHeist.canUseAbility(p)
+	end
 end)


### PR DESCRIPTION
title is self-explanatory, makes it so Twin Spin can be used on Jump with the sign, as opposed to only being a shield-less Spin
![srb22305](https://github.com/user-attachments/assets/9e44e99d-1c83-4225-8919-f0017235e689)
would require some multiplayer testing to see if it makes amy too powerful or not