### PR TITLE
team fixes + remove flashing check in fang's moveset

### DIFF
--- a/src/Lua/Hooks/Player.lua
+++ b/src/Lua/Hooks/Player.lua
@@ -54,6 +54,9 @@ addHook("PlayerThink", function(p)
 			and not (p.heist.lastbuttons & BT_JUMP) then
 				p.heist.confirmed_skin = true
 			end
+		elseif (p.heist.buttons & BT_SPIN)
+		and not (p.heist.lastbuttons & BT_SPIN) then
+			p.heist.confirmed_skin = false
 		end
 		
 		local showhud = CV_FindVar("showhud")
@@ -280,3 +283,16 @@ addHook("AbilitySpecial", function (p)
 		return not FangsHeist.canUseAbility(p)
 	end
 end)
+
+-- added this to Player.lua
+-- since its technically a player thing soo
+-- -pac
+addHook("MobjCollide", function(pmo, mo)
+	if not (mo.flags & MF_MISSILE)
+	or not (mo.target and mo.target.valid)
+	or not (mo.target.player and mo.target.player.valid) then return end
+	
+	local p = pmo.player
+	if FangsHeist.partOfTeam(p, mo.target.player)
+	or p.heist.blocking then return false end
+end, MT_PLAYER)

--- a/src/Lua/Modules/Drawers/leftscores.lua
+++ b/src/Lua/Modules/Drawers/leftscores.lua
@@ -46,7 +46,7 @@ function module.draw(v)
 			V_SNAPTOLEFT|V_SNAPTOTOP|(displayplayer.heist and FangsHeist.partOfTeam(displayplayer, p) and V_YELLOWMAP or 0),
 			"thin-fixed")
 
-		local str_width = v.stringWidth(p.name, 0, "thin")
+		local str_width = v.stringWidth(name, 0, "thin")
 
 		v.drawString(SCORE_X+2*FU+str_width*FU,
 			SCORE_Y+target_y,

--- a/src/Lua/Modules/Movesets/fang.lua
+++ b/src/Lua/Modules/Movesets/fang.lua
@@ -127,7 +127,7 @@ local function newGunslinger(player)
 	
 	//State: ready to gunsling
 	if not ((player.pflags & (PF_SLIDING|PF_BOUNCING|PF_THOKKED)) or (player.exiting) or (P_PlayerInPain(player)))
-	and not (player.powers[pw_flashing])
+	--and not (player.powers[pw_flashing]) -- i HATE player.powers[pw_flashing] >:( -pac
 	and not (player.weapondelay)
 	and not (player.panim == PA_ABILITY2)
 	and (player.pflags&PF_JUMPED or onground)

--- a/src/TODO.txt
+++ b/src/TODO.txt
@@ -20,4 +20,4 @@ fang - fang will call a miniature airstrike on an opponent
 
 itll be a small toy plane with a toy tails flying it, and itll drop small bombs
 
-metal sonic - he will unleash a blast
+metal sonic - he will unleash a (sonic) blast


### PR DESCRIPTION
- should fix up the team name screwing up the hud placement (didn't test that one);
- make so player projectiles don't interact with you if you're on the same team or blocking;
- remove the pw_flashing check in fang's moveset;
- aaand add a lil' "(sonic)" before blast!

I believe @Saxashitter is going to enjoy this 👀