### PR TITLE
fix team score freezing + team sign hit tweak

### DIFF
--- a/src/Lua/Functions/Getters.lua
+++ b/src/Lua/Functions/Getters.lua
@@ -70,20 +70,18 @@ end
 
 function FangsHeist.returnProfit(p, personal)
 	if not (p and p.heist) then return 0 end
-
-	if p.heist.exiting then
-		return p.heist.saved_profit
-	end
+	
 	if not FangsHeist.isPlayerAlive(p) then
 		return 0
 	end
-
+	
 	local profit = 0
-
-	if FangsHeist.playerHasSign(p) then
+	
+	if FangsHeist.playerHasSign(p)
+	or p.heist.had_sign then
 		profit = $+1500
 	end
-
+	
 	local div = 1
 	local length = FangsHeist.getTeamLength(p)
 	if length then

--- a/src/Lua/Modules/Handlers/escape.lua
+++ b/src/Lua/Modules/Handlers/escape.lua
@@ -126,8 +126,7 @@ local function module()
 		if not FangsHeist.isPlayerAtGate(p) then
 			continue
 		end
-
-		p.heist.saved_profit = FangsHeist.returnProfit(p)
+		
 		p.heist.exiting = true
 
 		if FangsHeist.playerHasSign(p) then

--- a/src/Lua/Modules/Handlers/pvp.lua
+++ b/src/Lua/Modules/Handlers/pvp.lua
@@ -96,11 +96,17 @@ function FangsHeist.damagePlayer(p, sp, projectile)
 	end
 
 	tier = max(1, min(FixedDiv(speed, 10*FU)/FU, #attackSounds))
-
-	if P_DamageMobj(sp.mo, (projectile and projectile.valid) and projectile or p.mo, p.mo) then
+	
+	local teamCheck = FangsHeist.partOfTeam(p, sp) and FangsHeist.playerHasSign(sp)
+	if teamCheck
+	or P_DamageMobj(sp.mo, (projectile and projectile.valid) and projectile or p.mo, p.mo) then
 		if not projectile then
 			S_StartSound(p.mo, attackSounds[tier][P_RandomRange(1, 2)])
 			FangsHeist.bouncePlayers(p, sp)
+			if teamCheck then
+				P_DoPlayerPain(sp, (projectile and projectile.valid) and projectile or p.mo, p.mo)
+				FangsHeist.giveSignTo(p)
+			end
 		end
 	end
 end
@@ -131,7 +137,7 @@ local function attackPlayers(p)
 			S_StartSound(sp.mo, sfx_s3k7b)
 			continue
 		end
-
+		
 		FangsHeist.damagePlayer(p, sp)
 	end
 end


### PR DESCRIPTION
should hopefully fix the team's score freezing up if the leader goes through the exit gate. Also makes it so the sign holder, if hit by you and they're part of your team, only give you the sign instead of fully damaging them, still knocking them out though.

pleaaase test the sign pvp team thingie i can't rn D: