### PR TITLE
Unlock Sound Test by Default & Amy Tweaks

### DIFF
--- a/src/Lua/Hooks/Player/init.lua
+++ b/src/Lua/Hooks/Player/init.lua
@@ -70,14 +70,25 @@ addHook("ShouldDamage", function(t,i,s,dmg,dt)
 		return false
 	end
 
+	local blockDeplete = FH_BLOCKDEPLETION
+	local forceDmg
 	if i
-	and i.valid
-	and i.type == MT_CORK then
-		if t.player.powers[pw_flashing] then
-			return false
+	and i.valid then
+		if i.type == MT_CORK then
+			if t.player.powers[pw_flashing]
+			or t.player.powers[pw_invulnerability] then
+				return false
+			end
 		end
-		if t.player.powers[pw_invulnerability] then
-			return false
+		
+		if i.type == MT_LHRT then
+			if t.player.powers[pw_flashing]
+			or t.player.powers[pw_invulnerability] then
+				return false
+			end
+			
+			blockDeplete = $/5
+			forceDmg = true
 		end
 	end
 
@@ -86,7 +97,7 @@ addHook("ShouldDamage", function(t,i,s,dmg,dt)
 	and s.player
 	and s.player.heist then
 		if t.player.heist.blocking then
-			t.player.heist.block_time = min(FH_BLOCKTIME, $+FH_BLOCKDEPLETION)
+			t.player.heist.block_time = min(FH_BLOCKTIME, $+blockDeplete)
 			if t.player.heist.block_time == FH_BLOCKTIME then
 				t.player.heist.block_cooldown = 5*TICRATE
 				t.player.heist.blocking = false
@@ -98,6 +109,7 @@ addHook("ShouldDamage", function(t,i,s,dmg,dt)
 			end
 		end
 	end
+	return forceDmg
 end, MT_PLAYER)
 
 addHook("MobjDamage", function(t,i,s,dmg,dt)

--- a/src/Lua/Movesets/Amy.lua
+++ b/src/Lua/Movesets/Amy.lua
@@ -88,7 +88,7 @@ addHook("PlayerThink", function(p)
 		init(p)
 	end
 
-	local attackFlags = STR_ATTACK|STR_WALL|STR_CEILING
+	local attackFlags = STR_ATTACK|STR_WALL|STR_CEILING|STR_SPIKE
 
 	if p.mo.state == S_FH_AMY_TWIRL then
 		local gravity = 3
@@ -136,6 +136,8 @@ addHook("AbilitySpecial", function(p)
 	if p.pflags & PF_JUMPED
 	and not (p.pflags & PF_THOKKED) then
 		p.heist.attack_cooldown = 85
+		S_StartSound(p.mo, sfx_s3k42) -- twinspin / melee / instashield sfx
+		--S_StartSound(p.mo, sfx_s1ab) -- jet jaw sfx
 		P_SetObjectMomZ(p.mo, 7*FU)
 		p.mo.state = S_FH_AMY_TWIRL
 		p.pflags = $|PF_THOKKED

--- a/src/SOC/SOC_HEAD
+++ b/src/SOC/SOC_HEAD
@@ -5,6 +5,12 @@ GameData = fangsheist.dat
 
 Clear All
 
+Unlockable 1
+Name = Sound Test
+Type = SoundTest
+Height = 10
+ConditionSet = -1
+
 Unlockable 2
 Unlockable 3
 Unlockable 23


### PR DESCRIPTION
- Sound Test is now unlocked by default
- Amy's double jump now has the ability to break spikes
  - It made sense to me, considering the anim
- Double Jump now plays the Twinspin / Melee / Instashield sfx when done
- Amy's hearts should now do damage to players!
  - Also makes it so they have 1/5th of the shield reduction a normal attack has, since there's 5 of 'em
  - Shield Reduction division results may not be super accurate, since shield time isn't a fixed number :P

ermmm, i'd say @Saxashitter would like to check this merge request out 👀