### PR TITLE
a bunch of stuff

### DIFF
--- a/src/Lua/Functions/Inits.lua
+++ b/src/Lua/Functions/Inits.lua
@@ -74,6 +74,16 @@ local bean_things = {
 	[409] = true
 }
 
+local replace_types = {
+	[MT_1UP_BOX] = MT_RING_BOX
+}
+
+local delete_types = { -- why wasnt this a table like the rest before? -pac
+	[MT_ATTRACT_BOX] = true,
+	[MT_INVULN_BOX] = true,
+	[MT_STARPOST] = true
+}
+
 function FangsHeist.loadMap()
 	FangsHeist.spawnSign()
 
@@ -82,12 +92,18 @@ function FangsHeist.loadMap()
 
 	for thing in mapthings.iterate do
 		if thing.mobj
-		and thing.mobj.valid
-		and (thing.mobj.type == MT_ATTRACT_BOX
-		or thing.mobj.type == MT_1UP_BOX
-		or thing.mobj.type == MT_INVULN_BOX
-		or thing.mobj.type == MT_STARPOST) then
-			P_RemoveMobj(thing.mobj)
+		and thing.mobj.valid then
+			if replace_types[thing.mobj.type] ~= nil then
+				local newtype = replace_types[thing.mobj.type]
+				P_RemoveMobj(thing.mobj)
+				
+				local mo = P_SpawnMobj(thing.x*FU, thing.y*FU, spawnpos.getThingSpawnHeight(newtype, thing, thing.x*FU, thing.y*FU), newtype)
+				if (thing.options & MTF_OBJECTFLIP) then
+					thing.flags2 = $^^MF2_OBJECTFLIP
+				end
+			elseif delete_types[thing.mobj.type] then
+				P_RemoveMobj(thing.mobj)
+			end
 		end
 
 		if thing.type == 3844 then

--- a/src/Lua/Hooks/Player/init.lua
+++ b/src/Lua/Hooks/Player/init.lua
@@ -27,6 +27,7 @@ addHook("PlayerThink", function(p)
 	if p.skin ~= p.heist.locked_skin then
 		R_SetPlayerSkin(p, p.heist.locked_skin)
 	end
+	p.score = FangsHeist.returnProfit(p)
 end)
 
 addHook("ThinkFrame", function(p)

--- a/src/Lua/Modules/Drawers/leftscores.lua
+++ b/src/Lua/Modules/Drawers/leftscores.lua
@@ -24,7 +24,9 @@ function module.draw(v)
 			if not (p and p.valid) then continue end
 			local life = v.getSprite2Patch(p.skin,
 				SPR2_LIFE, false, A, 0)
-	
+			
+			scale = skins[p.skin].highresscale/2
+			
 			v.drawScaled(SCORE_X+life.leftoffset*scale,
 				SCORE_Y+target_y+life.topoffset*scale-(2*scale),
 				scale,

--- a/src/Lua/Modules/Drawers/leftscores.lua
+++ b/src/Lua/Modules/Drawers/leftscores.lua
@@ -22,10 +22,14 @@ function module.draw(v)
 
 		for p,_ in pairs(p.heist.team.players) do
 			if not (p and p.valid) then continue end
-			local life = v.getSprite2Patch(p.skin,
-				SPR2_LIFE, false, A, 0)
-			
-			scale = skins[p.skin].highresscale/2
+			local life
+			if skins[p.skin].sprites[SPR2_LIFE].numframes then 
+				life = v.getSprite2Patch(p.skin,
+					SPR2_LIFE, false, A, 0)
+				scale = skins[p.skin].highresscale/2
+			else
+				life = v.cachePatch("CONTINS")
+			end
 			
 			v.drawScaled(SCORE_X+life.leftoffset*scale,
 				SCORE_Y+target_y+life.topoffset*scale-(2*scale),

--- a/src/Lua/Modules/Drawers/pregame.lua
+++ b/src/Lua/Modules/Drawers/pregame.lua
@@ -55,9 +55,9 @@ local function draw_cs(v,p)
 	for i = 0,#skins-1 do
 		local patch = v.getSprite2Patch(i, SPR2_LIFE, false, A)
 
-		local scale = FU
+		local scale = skins[i].highresscale
 		if i == p.heist.locked_skin then
-			scale = FU*3/2
+			scale = $*3/2
 		end
 		v.drawScaled(x + patch.leftoffset*scale,
 			y,

--- a/src/Lua/Modules/Drawers/pregame.lua
+++ b/src/Lua/Modules/Drawers/pregame.lua
@@ -53,14 +53,24 @@ local function draw_cs(v,p)
 	local x = 16*FU
 	local y = 60*FU
 	for i = 0,#skins-1 do
-		local patch = v.getSprite2Patch(i, SPR2_LIFE, false, A)
-
-		local scale = skins[i].highresscale
+		if not (p and p.valid) then continue end
+		
+		local patch
+		local scale = FU
+		local fakeyoffset = 0
+		if skins[i].sprites[SPR2_LIFE].numframes then 
+			patch = v.getSprite2Patch(i, SPR2_LIFE, false, A)
+			scale = skins[i].highresscale
+		else
+			patch = v.cachePatch("CONTINS")
+			fakeyoffset = 12
+		end
+		
 		if i == p.heist.locked_skin then
 			scale = $*3/2
 		end
 		v.drawScaled(x + patch.leftoffset*scale,
-			y,
+			y - fakeyoffset*scale,
 			scale,
 			patch,
 			V_SNAPTOLEFT|f,
@@ -86,7 +96,12 @@ local function draw_cs(v,p)
 	)
 
 	-- character
-	local patch = v.getSprite2Patch(p.heist.locked_skin, SPR2_XTRA, false, B)
+	local patch
+	if skins[p.heist.locked_skin].sprites[SPR2_XTRA].numframes >= 2 then -- B = 2 so, check if it has the B frame
+		patch = v.getSprite2Patch(p.heist.locked_skin, SPR2_XTRA, false, B)
+	else
+		patch = v.cachePatch("MISSING") -- what srb2 defaults to if XTRAB is missing
+	end
 	local scale = (FU/4)*3
 
 	local x = ease.outquad(

--- a/src/Lua/Modules/Drawers/treasuretracker.lua
+++ b/src/Lua/Modules/Drawers/treasuretracker.lua
@@ -8,10 +8,17 @@ local function draw_player(v, p, tp, mo, x, y)
 	local arrow_scale = FU/2
 	local dist = R_PointToDist2(mo.x, mo.y, p.mo.x, p.mo.y)
 
-	local plyr_spr = v.getSprite2Patch(p.mo.skin, SPR2_SIGN, false, A, 0)
+	local plyr_spr, plyr_scale
+	if skins[p.mo.skin].sprites[SPR2_SIGN].numframes then
+		plyr_spr = v.getSprite2Patch(p.mo.skin, SPR2_SIGN, false, A, 0)
+		plyr_scale = skins[p.mo.skin].highresscale
+	else
+		plyr_spr = v.getSpritePatch(SPR_SIGN, A, 0)
+		plyr_scale = FU
+	end
 	local color = v.getColormap(p.mo.skin, p.mo.color)
 
-	v.drawScaled(x, y, FU/4, plyr_spr, 0, color)
+	v.drawScaled(x, y, plyr_scale/4, plyr_spr, 0, color)
 	y = $-8*FU*2
 
 	if #p.heist.treasures then

--- a/src/Lua/Modules/Drawers/treasuretracker.lua
+++ b/src/Lua/Modules/Drawers/treasuretracker.lua
@@ -13,7 +13,7 @@ local function draw_player(v, p, tp, mo, x, y)
 		plyr_spr = v.getSprite2Patch(p.mo.skin, SPR2_SIGN, false, A, 0)
 		plyr_scale = skins[p.mo.skin].highresscale
 	else
-		plyr_spr = v.getSpritePatch(SPR_SIGN, A, 0)
+		plyr_spr = v.getSpritePatch(SPR_SIGN, S, 0)
 		plyr_scale = FU
 	end
 	local color = v.getColormap(p.mo.skin, p.mo.color)

--- a/src/Lua/Modules/Handlers/Intermission/highscores.lua
+++ b/src/Lua/Modules/Handlers/Intermission/highscores.lua
@@ -31,18 +31,25 @@ local function draw_data(v, data, i)
 	end
 
 	color = FangsHeist.getColorByName(color)
-
-	local life = v.getSprite2Patch(skin,
-		SPR2_LIFE, false, A, 0)
+	
+	local life
+	local scale = FU
+	if skins[skin].sprites[SPR2_LIFE].numframes then 
+		life = v.getSprite2Patch(skin,
+			SPR2_LIFE, false, A, 0)
+		scale = skins[skin].highresscale
+	else
+		life = v.cachePatch("CONTINS")
+	end
 
 	local x = 16*FU
 	local y = 40*FU
 
 	y = $+(10*((i-1)*FU))
 
-	v.drawScaled(x + (life.topoffset*FU/2),
-		y + (life.topoffset*FU/2),
-		FU/2,
+	v.drawScaled(x + (life.topoffset*scale/2),
+		y + (life.topoffset*scale/2),
+		scale/2,
 		life,
 		0,
 		v.getColormap(skin, color))

--- a/src/Lua/Modules/Handlers/Intermission/winners.lua
+++ b/src/Lua/Modules/Handlers/Intermission/winners.lua
@@ -69,8 +69,9 @@ function module.draw(v)
 		local p = plyrs[i]
 		local pos = POSITION_DATA[i]
 
+		local scale = skins[p.skin].highresscale
 		local stnd = v.getSprite2Patch(p.skin, SPR2_STND, false, A, 1)
-		local color = v.getColormap(p.skin, p.skincolor)
+		local color = v.getColormap(p.skin, p.skincolor, ((p.mo and p.mo.valid) and p.mo.translation or nil))
 
 		local podium = v.cachePatch(pos.patch)
 		local podium_scale = FU*6/8
@@ -81,7 +82,7 @@ function module.draw(v)
 		local name = (trim(p.name)):upper()
 
 		v.drawScaled(x-podium.width*podium_scale/2, 200*FU-podium.height*podium_scale, podium_scale, podium, V_SNAPTOBOTTOM|V_SNAPTOLEFT)
-		v.drawScaled(x, pos.y, FU*6/8, stnd, V_SNAPTOBOTTOM|V_SNAPTOLEFT, color)
+		v.drawScaled(x, pos.y, scale*6/8, stnd, V_SNAPTOBOTTOM|V_SNAPTOLEFT, color)
 
 		local y = pos.y+12*FU
 		local f = V_SNAPTOBOTTOM|V_SNAPTOLEFT

--- a/src/Lua/Modules/Handlers/dialogue.lua
+++ b/src/Lua/Modules/Handlers/dialogue.lua
@@ -120,7 +120,7 @@ DIALOGUE = {
     startFangPreset = function (name)
         print("Fang preset " .. name)
         local data = {
-            icon = fangdiag.portrait,
+            icon = (randSeed%69 == 0) and fangdiag.fankportrait or fangdiag.portrait,
             text = fangdiag[name][(randSeed % #fangdiag[name]) + 1],
             needsWrap = true
         }

--- a/src/Lua/Modules/Variables/fang_diag.lua
+++ b/src/Lua/Modules/Variables/fang_diag.lua
@@ -1,6 +1,7 @@
 local fangdiag = {}
 
 fangdiag.portrait = "FH_DIALOGUE_FANG_DEFAULT"
+fangdiag.fankportrait = "FH_DIALOGUE_FANK_DEFAULT"
 
 fangdiag["escapestart_nosign"] = {
 	"EY! Someone took the signpost! Don't you DARE leave without it! Do ya know how valuable it is!?",

--- a/src/Lua/Objects/Signpost.lua
+++ b/src/Lua/Objects/Signpost.lua
@@ -21,10 +21,10 @@ local function select_player(sign, p)
 			sign.bustmo.skin = p.mo.skin
 			sign.bustmo.color = p.skincolor
 			sign.bustmo.state = S_PLAY_SIGN
-		else -- just what A_SignPlayer does :P
-			sign.bustmo.skin = nil
+		else
+			sign.bustmo.skin = "sonic" -- apparently i can't set a skin to nil? sonic shouldn't have highresscale, atleast not in vanilla sooo
 			sign.bustmo.color = SKINCOLOR_NONE
-			sign.bustmo.skin = S_CLEARSIGN
+			sign.bustmo.state = S_CLEARSIGN
 		end
 	end
 

--- a/src/Lua/Objects/Signpost.lua
+++ b/src/Lua/Objects/Signpost.lua
@@ -17,9 +17,15 @@ local function select_player(sign, p)
 	sign.holder = p.mo
 	sign.hold_pos = {x = sign.x, y = sign.y, z = sign.z}
 	if sign.bustmo and sign.bustmo.valid then
-		sign.bustmo.skin = p.mo.skin
-		sign.bustmo.color = p.skincolor
-		sign.bustmo.state = S_PLAY_SIGN
+		if skins[p.mo.skin].sprites[SPR2_SIGN].numframes then
+			sign.bustmo.skin = p.mo.skin
+			sign.bustmo.color = p.skincolor
+			sign.bustmo.state = S_PLAY_SIGN
+		else -- just what A_SignPlayer does :P
+			sign.bustmo.skin = nil
+			sign.bustmo.color = SKINCOLOR_NONE
+			sign.bustmo.skin = S_CLEARSIGN
+		end
 	end
 
 	p.powers[pw_flashing] = TICRATE*2


### PR DESCRIPTION
adds:
- a replace_type table in Inits.lua
  - maybe check if this is the best way to replace an object?
  - as of right now makes it so 1ups are replaced by 10 ring monitors, as i felt it made sense to do so
- a delete_type table in  Inits.lua
  - same logic for the previous deleted objects, just made it a table like the other stuff was :P
- fallbacks for:
  - SPR2_LIFE in HUD (the CONTINS graphic, used in the continue screens)
  - SPR2_SIGN in HUD (should use the CLEAR! sign instead)
  - SPR2_SIGN in the grabbed Signpost (should use the CLEAR! sign instead of just the STND sprite)
  - XTRAB0 (CSS) in pre-game (should use the MISSING graphic, just like CSS does)
- makes the following use a character's highresscale on the HUD:
  - leftscores.lua
  - treasuretracker.lua
  - pregame.lua
  - highscores.lua
  - winners.lua
- fixes the vanilla leaderboard showing only the normal scores
  - just sets the player's score to their profit, probably not the best fix for this?
- 1 in 69 chance of fank appearing again
  - atleast i think it should be a 1 in 69 chance? i have surely not checked!

I think @Saxashitter will enjoy dissecting this line by line 👀